### PR TITLE
Adjusted 2 & 3 Horizontal radio panel radio panel layouts

### DIFF
--- a/DCS-SR-Client/DCS-SR-Client.csproj
+++ b/DCS-SR-Client/DCS-SR-Client.csproj
@@ -338,6 +338,12 @@
     <Compile Include="UI\RadioOverlayWindow\RadioOverlayThreeVertical.xaml.cs">
       <DependentUpon>RadioOverlayThreeVertical.xaml</DependentUpon>
     </Compile>
+    <Compile Include="UI\RadioOverlayWindow\Utils\IntercomControlGroup2Horizontal.xaml.cs">
+      <DependentUpon>IntercomControlGroup2Horizontal.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UI\RadioOverlayWindow\Utils\IntercomControlGroup3Horizontal.xaml.cs">
+      <DependentUpon>IntercomControlGroup3Horizontal.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI\RadioOverlayWindow\Utils\RadioCapabilities.xaml.cs">
       <DependentUpon>RadioCapabilities.xaml</DependentUpon>
     </Compile>
@@ -421,6 +427,14 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="UI\RadioOverlayWindow\RadioOverlayThreeVertical.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UI\RadioOverlayWindow\Utils\IntercomControlGroup2Horizontal.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="UI\RadioOverlayWindow\Utils\IntercomControlGroup3Horizontal.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsRadioControlGroup.xaml.cs
+++ b/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsRadioControlGroup.xaml.cs
@@ -392,7 +392,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.AwacsRadioOverlayWindow
 
                     if (currentRadio.modulation == RadioInformation.Modulation.AM)
                     {
-                        RadioMetaData.Text = "AM";
+                        //Dabble updated this
+                        //Changed Text to remove AM from here as AM is the default Modulation.
+                        //We are keeping the other modulations for better troubleshooting should anyone
+                        //change the modulation in the future
+                        RadioMetaData.Text = "";
                     }
                     else if (currentRadio.modulation == RadioInformation.Modulation.FM)
                     {
@@ -409,7 +413,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.AwacsRadioOverlayWindow
 
                     if (currentRadio.secFreq > 100)
                     {
-                        RadioMetaData.Text += " G";
+                        //Dabble updated this
+                        //Because are not using the secondary radios, we don't need to identify "Guard".
+                        //Original text here " G"
+                        RadioMetaData.Text += "";
                     }
 
                     if (currentRadio.channel > -1)

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayThreeHorizontal.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayThreeHorizontal.xaml
@@ -6,9 +6,9 @@
         Name="RadioOverlayWin"
         Title="DCS-SimpleRadio"
         Width="510"
-        Height="160"
+        Height="130"
         MinWidth="510"
-        MinHeight="160"
+        MinHeight="130"
         AllowsTransparency="True"
         Background="#444"
         Opacity="1.0"
@@ -38,7 +38,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="20" />
             <RowDefinition />
-            <RowDefinition Height="55" />
+            <RowDefinition Height="25" />
 
         </Grid.RowDefinitions>
 
@@ -132,31 +132,31 @@
             Orientation="Horizontal"
             VerticalAlignment="Center">
 
-            <local:IntercomControlGroup x:Name="intercom"
+            <local:IntercomControlGroup3Horizontal x:Name="intercom"
                                     Margin="0,0,0,0"
-                                    RadioId="0" Width="250" />
+                                    RadioId="0" Width="360" />
             <StackPanel
-                Orientation="Vertical"
+                Orientation="Horizontal"
                 HorizontalAlignment="Center"
-                VerticalAlignment="Top"
-                Margin="80,10,0,0">
+                VerticalAlignment="Center"
+                Margin="0,0,0,0">
                 <TextBlock x:Name="TrancparencyLabel"
-                   Width="130"
-                   Margin="10,0,10,0"
+                   Width="60"
+                   Margin="0,0,0,0"
                    VerticalAlignment="Center"
-                   HorizontalAlignment="Right"
-                   FontSize="12"
+                   HorizontalAlignment="Center"
+                   FontSize="8"
                    Foreground="#E7E7E7"
                    Padding="0"
                    Style="{x:Null}"
-                   Text="PANEL TRANSPARENCY"
+                   Text="TRANSPARENCY"
                    TextAlignment="Center"/>
 
                 <Slider x:Name="windowOpacitySlider"
-                    Width="120"
-                    Margin="0,0,20,0"
+                    Width="70"
+                    Margin="3,0,3,0"
                     VerticalAlignment="Center"
-                    HorizontalAlignment="Right"
+                    HorizontalAlignment="Center"
                     Maximum="1.0"
                     Minimum="0.05"
                     Style="{x:Null}"

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTwoHorizontal.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTwoHorizontal.xaml
@@ -6,9 +6,9 @@
         Name="RadioOverlayWin"
         Title="DCS-SimpleRadio"
         Width="340"
-        Height="160"
+        Height="135"
         MinWidth="340"
-        MinHeight="160"
+        MinHeight="135"
         AllowsTransparency="True"
         Background="#444"
         Opacity="1.0"
@@ -36,8 +36,8 @@
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="20" />
-            <RowDefinition />
-            <RowDefinition Height="55" />
+            <RowDefinition Height="85"/>
+            <RowDefinition Height="25" />
 
         </Grid.RowDefinitions>
 
@@ -127,27 +127,28 @@
             Orientation="Horizontal"
             VerticalAlignment="Center">
 
-            <local:IntercomControlGroup x:Name="intercom"
+            <local:IntercomControlGroup2Horizontal x:Name="intercom"
                                     Margin="0,0,0,0"
-                                    RadioId="0" Width="170" />
+                                    RadioId="0" Width="260" />
             <StackPanel
                 Orientation="Vertical"
-                VerticalAlignment="Center">
+                VerticalAlignment="Center"
+                HorizontalAlignment="Center">
                 <TextBlock x:Name="TrancparencyLabel"
-                       Width="130"
-                       Margin="10,0,10,0"
+                       Width="60"
+                       Margin="5,0,0,0"
                        VerticalAlignment="Center"
                        HorizontalAlignment="Right"
-                       FontSize="12"
+                       FontSize="8"
                        Foreground="#E7E7E7"
                        Padding="0"
                        Style="{x:Null}"
-                       Text="PANEL TRANSPARENCY"
+                       Text="TRANSPARENCY"
                        TextAlignment="Center"/>
 
                 <Slider x:Name="windowOpacitySlider"
-                        Width="120"
-                        Margin="0,0,20,0"
+                        Width="60"
+                        Margin="5,0,0,0"
                         VerticalAlignment="Center"
                         HorizontalAlignment="Right"
                         Maximum="1.0"

--- a/DCS-SR-Client/UI/RadioOverlayWindow/Utils/IntercomControlGroup2Horizontal.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/Utils/IntercomControlGroup2Horizontal.xaml
@@ -1,0 +1,106 @@
+﻿<UserControl x:Class="Ciribob.DCS.SimpleRadio.Standalone.Overlay.IntercomControlGroup2Horizontal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Overlay"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             Name="RadioControlContainer"
+             Width="260"
+             Height="18">
+    <StackPanel Margin="3,0,3,0" Orientation="Horizontal">
+        <WrapPanel HorizontalAlignment="Left">
+            <TextBlock x:Name="RadioLabel"
+                       Width="15"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       FontSize="10"
+                       Foreground="#E7E7E7"
+                       Padding="0,0,0,0"
+                       Style="{x:Null}"
+                       Text="I/C"
+                       TextAlignment="Center" />
+
+            <Slider x:Name="RadioVolume"
+                    Width="60"
+                    Height="20"
+                    IsEnabled="True"
+                    Margin="3,0,3,0"
+                    VerticalAlignment="Center"
+                    Maximum="100"
+                    Style="{x:Null}"
+                    Thumb.DragCompleted="RadioVolume_DragCompleted"
+                    Thumb.DragStarted="RadioVolume_DragStarted" />
+
+            <xctk:IntegerUpDown x:Name="IntercomNumberSpinner"
+                VerticalAlignment="Center"
+                Width="40"
+                Height="18"
+                ValueChanged="IntercomNumber_SpinnerChanged"
+                Value="1"/>
+
+            <Ellipse x:Name="RadioActive"
+                 Width="12"
+                 Height="12"
+                 Margin="2"
+                 HorizontalAlignment="Right"
+                 VerticalAlignment="Center"
+                 Fill="#FF9900"
+                 MouseDown="RadioSelectSwitch"
+                 Stroke="Black"
+                 Style="{x:Null}"
+                 ToolTip="Selected Radio" />
+
+        </WrapPanel>
+
+        <Line
+             X1="0" Y1="0"
+             X2="0" Y2="50"
+             Stroke="#ACACAC"
+             StrokeThickness="2"
+             Margin="5,0,2,0"/>
+
+        <WrapPanel 
+            Width="138"
+            Margin="2,0,0,0"
+            ToolTip="Select the VOX Input mode you want to use. (Intercom Channel 1 Disabled)">
+            <TextBlock x:Name="VOXLabel"
+               Margin="2,0,2,0"
+               Width="20"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"
+               FontSize="9"
+               Foreground="#E7E7E7"
+               Padding="0,0,0,0"
+               Style="{x:Null}"
+               Text="VOX"
+               TextAlignment="Center" />
+
+            <Button x:Name="Radio1Enabled"
+                Width="40"
+                FontSize="9"
+                Height="18"
+                Margin="0,0,2,0"
+                VerticalAlignment="Center"
+                Content="R1"
+                IsEnabled="True"
+                Foreground="Black"
+                Style="{StaticResource DarkStyle-Button}"
+                Click="VoxR1Enabled_OnClick"
+                ToolTip="enable / disable voice activated communications for Radio 1"/>
+
+            <Button x:Name="IntercomEnabled"
+                Width="40"
+                FontSize="9"
+                Height="18"
+                Margin="2,0,0,0"
+                VerticalAlignment="Center"
+                Content="IC"
+                IsEnabled="False"
+                Foreground="Black"
+                Style="{StaticResource DarkStyle-Button}"
+                Click="VoxICEnabled_OnClick"
+                ToolTip="enable / disable voice activated communications for Intercom (Channel 1 Disabled)"/>
+        </WrapPanel>
+    </StackPanel>
+</UserControl>

--- a/DCS-SR-Client/UI/RadioOverlayWindow/Utils/IntercomControlGroup2Horizontal.xaml.cs
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/Utils/IntercomControlGroup2Horizontal.xaml.cs
@@ -1,0 +1,271 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.Network;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.Settings;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons;
+using Ciribob.DCS.SimpleRadio.Standalone.Common;
+using Newtonsoft.Json.Linq;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
+{
+    /// <summary>
+    ///     Interaction logic for IntercomControlGroup2Horizontal.xaml
+    /// </summary>
+    public partial class IntercomControlGroup2Horizontal : UserControl
+    {
+        private bool _dragging;
+
+        private bool _init = true;
+        private readonly ClientStateSingleton _clientStateSingleton = ClientStateSingleton.Instance;
+        private readonly GlobalSettingsStore _globalSettings = GlobalSettingsStore.Instance;
+        // Color for Vox Button
+        public static Brush voxEnabled = Brushes.MediumSeaGreen;
+        public static Brush voxDisabled = Brushes.IndianRed;
+        public static Brush voxicDisabled = Brushes.Gray;
+        private RadioInformation _inercomRadioInfo;
+
+        public IntercomControlGroup2Horizontal()
+        {
+            InitializeComponent();
+
+            Radio1Enabled.Background = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXR1) ? voxEnabled : voxDisabled;
+            IntercomEnabled.Background = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC) ? voxEnabled : voxicDisabled;
+            _inercomRadioInfo = _clientStateSingleton.DcsPlayerRadioInfo.radios[RadioId];
+            IntercomNumberSpinner.Maximum = (int)Math.Round(_inercomRadioInfo.freqMax, 0);
+            IntercomNumberSpinner.Minimum = 1;
+            IntercomEnabled.IsEnabled = IntercomNumberSpinner.Value != 1;
+        }
+
+        public int RadioId { private get; set; }
+
+        private void RadioSelectSwitch(object sender, RoutedEventArgs e)
+        {
+            if (_inercomRadioInfo.modulation != RadioInformation.Modulation.DISABLED)
+            {
+                if (_clientStateSingleton.DcsPlayerRadioInfo.control ==
+                    DCSPlayerRadioInfo.RadioSwitchControls.HOTAS)
+                {
+                    _clientStateSingleton.DcsPlayerRadioInfo.selected = (short)RadioId;
+                }
+            }
+        }
+
+        private void RadioVolume_DragStarted(object sender, RoutedEventArgs e)
+        {
+            _dragging = true;
+        }
+
+
+        private void RadioVolume_DragCompleted(object sender, RoutedEventArgs e)
+        {
+            var currentRadio = _clientStateSingleton.DcsPlayerRadioInfo.radios[RadioId];
+
+            if (currentRadio.modulation != RadioInformation.Modulation.DISABLED)
+            {
+                if (currentRadio.volMode == RadioInformation.VolumeMode.OVERLAY)
+                {
+                    var clientRadio = _clientStateSingleton.DcsPlayerRadioInfo.radios[RadioId];
+
+                    clientRadio.volume = (float)RadioVolume.Value / 100.0f;
+                }
+            }
+
+            _dragging = false;
+        }
+
+        internal void RepaintRadioStatus()
+        {
+            var dcsPlayerRadioInfo = _clientStateSingleton.DcsPlayerRadioInfo;
+
+            if ((dcsPlayerRadioInfo == null) || !dcsPlayerRadioInfo.IsCurrent())
+            {
+                RadioActive.Fill = new SolidColorBrush(Colors.Red);
+
+                RadioVolume.IsEnabled = false;
+
+                //reset dragging just incase
+                _dragging = false;
+
+                IntercomNumberSpinner.IsEnabled = false;
+            }
+            else
+            {
+                var currentRadio = dcsPlayerRadioInfo.radios[RadioId];
+                var transmitting = _clientStateSingleton.RadioSendingState;
+                var receiveState = _clientStateSingleton.RadioReceivingState[RadioId];
+                if ((receiveState != null) && receiveState.IsReceiving)
+                {
+                    RadioActive.Fill = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#96FF6D"));
+                }
+                else if (RadioId == dcsPlayerRadioInfo.selected || transmitting.IsSending && (transmitting.SendingOn == RadioId))
+                {
+
+                    if (transmitting.IsSending && (transmitting.SendingOn == RadioId))
+                    {
+                        RadioActive.Fill = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#96FF6D"));
+                    }
+                    else
+                    {
+                        RadioActive.Fill = new SolidColorBrush(Colors.Green);
+                    }
+                }
+                else
+                {
+                    if (currentRadio.simul && dcsPlayerRadioInfo.simultaneousTransmission)
+                    {
+                        // if (transmitting.IsSending)
+                        // {
+                        //     RadioActive.Fill = new SolidColorBrush(Colors.LightBlue);
+                        // }
+                        // else
+                        // {
+                        RadioActive.Fill = new SolidColorBrush(Colors.DarkBlue);
+                        // }
+
+                    }
+                    else
+                    {
+                        RadioActive.Fill = new SolidColorBrush(Colors.Orange);
+                    }
+
+                }
+
+                if (currentRadio.modulation == RadioInformation.Modulation.INTERCOM) //intercom
+                {
+                    //Dabble removing this functionality
+                    //RadioLabel.Text = "VOX / INTERCOM";
+
+                    Radio1Enabled.IsEnabled = true;
+                    if (IntercomNumberSpinner.Value != 1)
+                    {
+                        IntercomEnabled.IsEnabled = true;
+                    }
+                    IntercomNumberSpinner.IsEnabled = true;
+
+                    if (dcsPlayerRadioInfo.unitId >= DCSPlayerRadioInfo.UnitIdOffset)
+                    {
+                        IntercomNumberSpinner.IsEnabled = true;
+                        IntercomNumberSpinner.Value = _clientStateSingleton.IntercomOffset;
+                    }
+                    else
+                    {
+                        IntercomNumberSpinner.IsEnabled = false;
+                        IntercomNumberSpinner.Value = 1;
+                        _clientStateSingleton.IntercomOffset = 1;
+                    }
+                }
+                else
+                {
+                    RadioLabel.Text = "NO VOX / INTERCOM";
+                    RadioActive.Fill = new SolidColorBrush(Colors.Red);
+                    Radio1Enabled.IsEnabled = false;
+                    IntercomEnabled.IsEnabled = false;
+                    RadioVolume.IsEnabled = false;
+                    IntercomNumberSpinner.Value = 1;
+                    IntercomNumberSpinner.IsEnabled = false;
+                    _clientStateSingleton.IntercomOffset = 1;
+
+                    Radio1Enabled.Background = voxicDisabled;
+                    IntercomEnabled.Background = voxicDisabled;
+                }
+
+                if (_dragging == false)
+                {
+                    RadioVolume.Value = currentRadio.volume * 100.0;
+                }
+            }
+        }
+
+        private void VoxR1Enabled_OnClick(object sender, RoutedEventArgs e)
+        {
+            _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXR1, !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXR1));
+
+            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXR1))
+            {
+                Radio1Enabled.Background = voxEnabled;
+                if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC))
+                {
+                    _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXIC, false);
+                    IntercomEnabled.Background = voxDisabled;
+                }
+            }
+            else
+            {
+                Radio1Enabled.Background = voxDisabled;
+            }
+        }
+
+        private void VoxICEnabled_OnClick(object sender, RoutedEventArgs e)
+        {
+            _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXIC, !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC));
+
+            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC))
+            {
+                IntercomEnabled.Background = voxEnabled;
+                if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXR1))
+                {
+                    _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXR1, false);
+                    Radio1Enabled.Background = voxDisabled;
+                }
+            }
+            else
+            {
+                IntercomEnabled.Background = voxDisabled;
+            }
+        }
+
+        private void IntercomNumber_SpinnerChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            if (_init)
+            {
+                //ignore
+                _init = false;
+                return;
+            }
+
+            int spinnervalue;
+            if (!int.TryParse(IntercomNumberSpinner.Value.ToString(), out spinnervalue))
+            {
+                return;
+            }
+            
+            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC))
+            {
+                _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXIC, !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC));
+                IntercomEnabled.Background = voxDisabled;
+            }
+
+
+            if (spinnervalue == 1)
+            {
+                IntercomEnabled.IsEnabled = false;
+                IntercomEnabled.Background = voxicDisabled;
+            }
+            else
+            {
+                IntercomEnabled.IsEnabled = true;
+                if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC))
+                {
+                    IntercomEnabled.Background = voxEnabled;
+                }
+                else
+                {
+                    IntercomEnabled.Background = voxDisabled;
+                }
+            }
+
+            var dcsPlayerRadioInfo = _clientStateSingleton.DcsPlayerRadioInfo;
+
+            if ((dcsPlayerRadioInfo != null) && dcsPlayerRadioInfo.IsCurrent() &&
+                (dcsPlayerRadioInfo.unitId >= DCSPlayerRadioInfo.UnitIdOffset))
+            {
+                _clientStateSingleton.IntercomOffset = (int)IntercomNumberSpinner.Value;
+                dcsPlayerRadioInfo.unitId =
+                    (uint)(DCSPlayerRadioInfo.UnitIdOffset + _clientStateSingleton.IntercomOffset);
+                _clientStateSingleton.LastSent = 0; //force refresh
+            }
+        }
+    }
+}

--- a/DCS-SR-Client/UI/RadioOverlayWindow/Utils/IntercomControlGroup3Horizontal.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/Utils/IntercomControlGroup3Horizontal.xaml
@@ -1,0 +1,106 @@
+﻿<UserControl x:Class="Ciribob.DCS.SimpleRadio.Standalone.Overlay.IntercomControlGroup3Horizontal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:Ciribob.DCS.SimpleRadio.Standalone.Overlay"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             Name="RadioControlContainer"
+             Width="360"
+             Height="18">
+    <StackPanel Margin="3,0,3,0" Orientation="Horizontal">
+        <WrapPanel HorizontalAlignment="Left">
+            <TextBlock x:Name="RadioLabel"
+                       Width="90"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       FontSize="10"
+                       Foreground="#E7E7E7"
+                       Padding="0,0,0,0"
+                       Style="{x:Null}"
+                       Text="VOX / INTERCOM"
+                       TextAlignment="Center" />
+
+            <Slider x:Name="RadioVolume"
+                    Width="60"
+                    Height="20"
+                    IsEnabled="True"
+                    Margin="0,0,3,0"
+                    VerticalAlignment="Center"
+                    Maximum="100"
+                    Style="{x:Null}"
+                    Thumb.DragCompleted="RadioVolume_DragCompleted"
+                    Thumb.DragStarted="RadioVolume_DragStarted" />
+
+            <xctk:IntegerUpDown x:Name="IntercomNumberSpinner"
+                VerticalAlignment="Center"
+                Width="40"
+                Height="18"
+                ValueChanged="IntercomNumber_SpinnerChanged"
+                Value="1"/>
+
+            <Ellipse x:Name="RadioActive"
+                 Width="12"
+                 Height="12"
+                 Margin="2"
+                 HorizontalAlignment="Right"
+                 VerticalAlignment="Center"
+                 Fill="#FF9900"
+                 MouseDown="RadioSelectSwitch"
+                 Stroke="Black"
+                 Style="{x:Null}"
+                 ToolTip="Selected Radio" />
+
+        </WrapPanel>
+
+        <Line
+             X1="0" Y1="0"
+             X2="0" Y2="50"
+             Stroke="#ACACAC"
+             StrokeThickness="2"
+             Margin="5,0,2,0"/>
+
+        <WrapPanel 
+            Width="138"
+            Margin="2,0,0,0"
+            ToolTip="Select the VOX Input mode you want to use. (Intercom Channel 1 Disabled)">
+            <TextBlock x:Name="VOXLabel"
+               Margin="2,0,2,0"
+               Width="40"
+               HorizontalAlignment="Center"
+               VerticalAlignment="Center"
+               FontSize="9"
+               Foreground="#E7E7E7"
+               Padding="0,0,0,0"
+               Style="{x:Null}"
+               Text="VOX SEL"
+               TextAlignment="Center" />
+
+            <Button x:Name="Radio1Enabled"
+                Width="40"
+                FontSize="9"
+                Height="18"
+                Margin="0,0,2,0"
+                VerticalAlignment="Center"
+                Content="R1"
+                IsEnabled="True"
+                Foreground="Black"
+                Style="{StaticResource DarkStyle-Button}"
+                Click="VoxR1Enabled_OnClick"
+                ToolTip="enable / disable voice activated communications for Radio 1"/>
+
+            <Button x:Name="IntercomEnabled"
+                Width="40"
+                FontSize="9"
+                Height="18"
+                Margin="2,0,0,0"
+                VerticalAlignment="Center"
+                Content="IC"
+                IsEnabled="False"
+                Foreground="Black"
+                Style="{StaticResource DarkStyle-Button}"
+                Click="VoxICEnabled_OnClick"
+                ToolTip="enable / disable voice activated communications for Intercom (Channel 1 Disabled)"/>
+        </WrapPanel>
+    </StackPanel>
+</UserControl>

--- a/DCS-SR-Client/UI/RadioOverlayWindow/Utils/IntercomControlGroup3Horizontal.xaml.cs
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/Utils/IntercomControlGroup3Horizontal.xaml.cs
@@ -1,0 +1,270 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.Network;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.Settings;
+using Ciribob.DCS.SimpleRadio.Standalone.Client.Singletons;
+using Ciribob.DCS.SimpleRadio.Standalone.Common;
+using Newtonsoft.Json.Linq;
+
+namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
+{
+    /// <summary>
+    ///     Interaction logic for IntercomControlGroup3Horizontal.xaml
+    /// </summary>
+    public partial class IntercomControlGroup3Horizontal : UserControl
+    {
+        private bool _dragging;
+
+        private bool _init = true;
+        private readonly ClientStateSingleton _clientStateSingleton = ClientStateSingleton.Instance;
+        private readonly GlobalSettingsStore _globalSettings = GlobalSettingsStore.Instance;
+        // Color for Vox Button
+        public static Brush voxEnabled = Brushes.MediumSeaGreen;
+        public static Brush voxDisabled = Brushes.IndianRed;
+        public static Brush voxicDisabled = Brushes.Gray;
+        private RadioInformation _inercomRadioInfo;
+
+        public IntercomControlGroup3Horizontal()
+        {
+            InitializeComponent();
+
+            Radio1Enabled.Background = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXR1) ? voxEnabled : voxDisabled;
+            IntercomEnabled.Background = _globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC) ? voxEnabled : voxicDisabled;
+            _inercomRadioInfo = _clientStateSingleton.DcsPlayerRadioInfo.radios[RadioId];
+            IntercomNumberSpinner.Maximum = (int)Math.Round(_inercomRadioInfo.freqMax, 0);
+            IntercomNumberSpinner.Minimum = 1;
+            IntercomEnabled.IsEnabled = IntercomNumberSpinner.Value != 1;
+        }
+
+        public int RadioId { private get; set; }
+
+        private void RadioSelectSwitch(object sender, RoutedEventArgs e)
+        {
+            if (_inercomRadioInfo.modulation != RadioInformation.Modulation.DISABLED)
+            {
+                if (_clientStateSingleton.DcsPlayerRadioInfo.control ==
+                    DCSPlayerRadioInfo.RadioSwitchControls.HOTAS)
+                {
+                    _clientStateSingleton.DcsPlayerRadioInfo.selected = (short)RadioId;
+                }
+            }
+        }
+
+        private void RadioVolume_DragStarted(object sender, RoutedEventArgs e)
+        {
+            _dragging = true;
+        }
+
+
+        private void RadioVolume_DragCompleted(object sender, RoutedEventArgs e)
+        {
+            var currentRadio = _clientStateSingleton.DcsPlayerRadioInfo.radios[RadioId];
+
+            if (currentRadio.modulation != RadioInformation.Modulation.DISABLED)
+            {
+                if (currentRadio.volMode == RadioInformation.VolumeMode.OVERLAY)
+                {
+                    var clientRadio = _clientStateSingleton.DcsPlayerRadioInfo.radios[RadioId];
+
+                    clientRadio.volume = (float)RadioVolume.Value / 100.0f;
+                }
+            }
+
+            _dragging = false;
+        }
+
+        internal void RepaintRadioStatus()
+        {
+            var dcsPlayerRadioInfo = _clientStateSingleton.DcsPlayerRadioInfo;
+
+            if ((dcsPlayerRadioInfo == null) || !dcsPlayerRadioInfo.IsCurrent())
+            {
+                RadioActive.Fill = new SolidColorBrush(Colors.Red);
+
+                RadioVolume.IsEnabled = false;
+
+                //reset dragging just incase
+                _dragging = false;
+
+                IntercomNumberSpinner.IsEnabled = false;
+            }
+            else
+            {
+                var currentRadio = dcsPlayerRadioInfo.radios[RadioId];
+                var transmitting = _clientStateSingleton.RadioSendingState;
+                var receiveState = _clientStateSingleton.RadioReceivingState[RadioId];
+                if ((receiveState != null) && receiveState.IsReceiving)
+                {
+                    RadioActive.Fill = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#96FF6D"));
+                }
+                else if (RadioId == dcsPlayerRadioInfo.selected || transmitting.IsSending && (transmitting.SendingOn == RadioId))
+                {
+
+                    if (transmitting.IsSending && (transmitting.SendingOn == RadioId))
+                    {
+                        RadioActive.Fill = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#96FF6D"));
+                    }
+                    else
+                    {
+                        RadioActive.Fill = new SolidColorBrush(Colors.Green);
+                    }
+                }
+                else
+                {
+                    if (currentRadio.simul && dcsPlayerRadioInfo.simultaneousTransmission)
+                    {
+                        // if (transmitting.IsSending)
+                        // {
+                        //     RadioActive.Fill = new SolidColorBrush(Colors.LightBlue);
+                        // }
+                        // else
+                        // {
+                        RadioActive.Fill = new SolidColorBrush(Colors.DarkBlue);
+                        // }
+
+                    }
+                    else
+                    {
+                        RadioActive.Fill = new SolidColorBrush(Colors.Orange);
+                    }
+
+                }
+
+                if (currentRadio.modulation == RadioInformation.Modulation.INTERCOM) //intercom
+                {
+                    RadioLabel.Text = "VOX / INTERCOM";
+
+                    Radio1Enabled.IsEnabled = true;
+                    if (IntercomNumberSpinner.Value != 1)
+                    {
+                        IntercomEnabled.IsEnabled = true;
+                    }
+                    IntercomNumberSpinner.IsEnabled = true;
+
+                    if (dcsPlayerRadioInfo.unitId >= DCSPlayerRadioInfo.UnitIdOffset)
+                    {
+                        IntercomNumberSpinner.IsEnabled = true;
+                        IntercomNumberSpinner.Value = _clientStateSingleton.IntercomOffset;
+                    }
+                    else
+                    {
+                        IntercomNumberSpinner.IsEnabled = false;
+                        IntercomNumberSpinner.Value = 1;
+                        _clientStateSingleton.IntercomOffset = 1;
+                    }
+                }
+                else
+                {
+                    RadioLabel.Text = "NO VOX / INTERCOM";
+                    RadioActive.Fill = new SolidColorBrush(Colors.Red);
+                    Radio1Enabled.IsEnabled = false;
+                    IntercomEnabled.IsEnabled = false;
+                    RadioVolume.IsEnabled = false;
+                    IntercomNumberSpinner.Value = 1;
+                    IntercomNumberSpinner.IsEnabled = false;
+                    _clientStateSingleton.IntercomOffset = 1;
+
+                    Radio1Enabled.Background = voxicDisabled;
+                    IntercomEnabled.Background = voxicDisabled;
+                }
+
+                if (_dragging == false)
+                {
+                    RadioVolume.Value = currentRadio.volume * 100.0;
+                }
+            }
+        }
+
+        private void VoxR1Enabled_OnClick(object sender, RoutedEventArgs e)
+        {
+            _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXR1, !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXR1));
+
+            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXR1))
+            {
+                Radio1Enabled.Background = voxEnabled;
+                if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC))
+                {
+                    _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXIC, false);
+                    IntercomEnabled.Background = voxDisabled;
+                }
+            }
+            else
+            {
+                Radio1Enabled.Background = voxDisabled;
+            }
+        }
+
+        private void VoxICEnabled_OnClick(object sender, RoutedEventArgs e)
+        {
+            _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXIC, !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC));
+
+            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC))
+            {
+                IntercomEnabled.Background = voxEnabled;
+                if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXR1))
+                {
+                    _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXR1, false);
+                    Radio1Enabled.Background = voxDisabled;
+                }
+            }
+            else
+            {
+                IntercomEnabled.Background = voxDisabled;
+            }
+        }
+
+        private void IntercomNumber_SpinnerChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            if (_init)
+            {
+                //ignore
+                _init = false;
+                return;
+            }
+
+            int spinnervalue;
+            if (!int.TryParse(IntercomNumberSpinner.Value.ToString(), out spinnervalue))
+            {
+                return;
+            }
+            
+            if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC))
+            {
+                _globalSettings.SetClientSetting(GlobalSettingsKeys.VOXIC, !_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC));
+                IntercomEnabled.Background = voxDisabled;
+            }
+
+
+            if (spinnervalue == 1)
+            {
+                IntercomEnabled.IsEnabled = false;
+                IntercomEnabled.Background = voxicDisabled;
+            }
+            else
+            {
+                IntercomEnabled.IsEnabled = true;
+                if (_globalSettings.GetClientSettingBool(GlobalSettingsKeys.VOXIC))
+                {
+                    IntercomEnabled.Background = voxEnabled;
+                }
+                else
+                {
+                    IntercomEnabled.Background = voxDisabled;
+                }
+            }
+
+            var dcsPlayerRadioInfo = _clientStateSingleton.DcsPlayerRadioInfo;
+
+            if ((dcsPlayerRadioInfo != null) && dcsPlayerRadioInfo.IsCurrent() &&
+                (dcsPlayerRadioInfo.unitId >= DCSPlayerRadioInfo.UnitIdOffset))
+            {
+                _clientStateSingleton.IntercomOffset = (int)IntercomNumberSpinner.Value;
+                dcsPlayerRadioInfo.unitId =
+                    (uint)(DCSPlayerRadioInfo.UnitIdOffset + _clientStateSingleton.IntercomOffset);
+                _clientStateSingleton.LastSent = 0; //force refresh
+            }
+        }
+    }
+}

--- a/DCS-SimpleRadioStandalone.sln
+++ b/DCS-SimpleRadioStandalone.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29424.173
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34316.72
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpusWrapper", "OpusWrapper\OpusWrapper.csproj", "{838BDB0B-5EB1-4C1E-9026-0A8842AC00C6}"
 EndProject
@@ -27,18 +27,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Installer", "Installer\Inst
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{68C7B1F8-DF0E-4504-8C7D-6FEF4225466B}"
 	ProjectSection(SolutionItems) = preProject
+		Scripts\DCS-SRS\Scripts\DCS-Plugin-Example\SRS\autoload.lua = Scripts\DCS-SRS\Scripts\DCS-Plugin-Example\SRS\autoload.lua
 		install-build\awacs-radios.json = install-build\awacs-radios.json
-		install-build\vngd-channels.txt = install-build\vngd-channels.txt
+		Scripts\DCS-SRS\Scripts\DCS-SimpleRadioStandalone.lua = Scripts\DCS-SRS\Scripts\DCS-SimpleRadioStandalone.lua
 		Scripts\DCS-SRS-AutoConnectGameGUI.lua = Scripts\DCS-SRS-AutoConnectGameGUI.lua
+		Scripts\Hooks\DCS-SRS-hook.lua = Scripts\Hooks\DCS-SRS-hook.lua
 		Scripts\DCS-SRS\UI\DCS-SRS-Overlay.dlg = Scripts\DCS-SRS\UI\DCS-SRS-Overlay.dlg
+		Scripts\DCS-SRS\Scripts\DCS-SRS-OverlayGameGUI.lua = Scripts\DCS-SRS\Scripts\DCS-SRS-OverlayGameGUI.lua
+		Scripts\DCS-SRS\Scripts\DCS-SRSGameGUI.lua = Scripts\DCS-SRS\Scripts\DCS-SRSGameGUI.lua
 		Scripts\DCS-SRS\entry.lua = Scripts\DCS-SRS\entry.lua
 		Scripts\Export.lua = Scripts\Export.lua
-		Scripts\Hooks\DCS-SRS-hook.lua = Scripts\Hooks\DCS-SRS-hook.lua
-		Scripts\DCS-SRS\Scripts\DCS-SimpleRadioStandalone.lua = Scripts\DCS-SRS\Scripts\DCS-SimpleRadioStandalone.lua
-		Scripts\DCS-SRS\Scripts\DCS-SRSGameGUI.lua = Scripts\DCS-SRS\Scripts\DCS-SRSGameGUI.lua
-		Scripts\DCS-SRS\Scripts\DCS-SRS-OverlayGameGUI.lua = Scripts\DCS-SRS\Scripts\DCS-SRS-OverlayGameGUI.lua
 		Scripts\DCS-SRS\Scripts\DCS-Plugin-Example\Readme.txt = Scripts\DCS-SRS\Scripts\DCS-Plugin-Example\Readme.txt
-		Scripts\DCS-SRS\Scripts\DCS-Plugin-Example\SRS\autoload.lua = Scripts\DCS-SRS\Scripts\DCS-Plugin-Example\SRS\autoload.lua
+		install-build\vngd-channels.txt = install-build\vngd-channels.txt
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DCS-SR-CommonTests", "DCS-SR-CommonTests\DCS-SR-CommonTests.csproj", "{A0245CB5-7C06-4FC7-9477-ECB0D1A88239}"


### PR DESCRIPTION
- Made the 3 horizontal radio panel more condensed
- Created 2 Horizontal Intercom class and specific layout adjustments in order to condense it
- Updated radiometadata text to no longer display "AM" and " G". The code is still in place if we need to revert for whatever reason
- Condensed the 2H radio panel
- removed the 2H radio label update for the intercom (commented out)