### PR TITLE
Fix PTT bug on disabled radio

### DIFF
--- a/DCS-SR-Client/Network/UDPVoiceHandler.cs
+++ b/DCS-SR-Client/Network/UDPVoiceHandler.cs
@@ -172,15 +172,16 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.Network
                                         //Store last release time
                                     }
                                 }
-                                else
-                                {
-                                    //turn on PTT even if not valid radio switch
-                                    if (radioSwitchPtt)
-                                    {
-                                        _lastPTTPress = DateTime.Now.Ticks;
-                                        ptt = true;
-                                    }
-                                }
+                                // commented out this code because we do not want to turn on PTT if radio is disabled
+                                //else
+                                //{
+                                //    //turn on PTT even if not valid radio switch
+                                //    if (radioSwitchPtt)
+                                //    {
+                                //        _lastPTTPress = DateTime.Now.Ticks;
+                                //        ptt = true;
+                                //    }
+                                //}
 
                             }
                         }


### PR DESCRIPTION
In UDPVoiceHandler.cs line 165 there was already a check to see if radio is enabled before turning on PTT but the else block of the if statement still turned on PTT anyway. I can leave the code commented out or delete it. Let me know what you all think.

<img width="784" alt="image" src="https://github.com/FPGSchiba/VNGD-SimpleRadioStandalone/assets/28220658/13e84d5c-4bbc-45b8-a147-c14c7ddf057d">
