### PR TITLE
Version 1.3.3

### DIFF
--- a/DCS-SR-Client/App.xaml.cs
+++ b/DCS-SR-Client/App.xaml.cs
@@ -247,7 +247,7 @@ namespace DCS_SR_Client
                 DetectConsoleAvailable = true,
                 Name = "consoleTarget",
                 StdErr = false,
-                Layout = @"${longdate} | ${logger} | ${message} ${exception:format=toString,Data:maxInnerExceptionLevel=1}"
+                Layout = @"${longdate} | ${logger} (${level}) | ${message} ${exception:format=toString,Data:maxInnerExceptionLevel=1}"
             };
             var consoleWrapper = new AsyncTargetWrapper(consoleTarget, 5000, AsyncTargetWrapperOverflowAction.Discard);
             config.AddTarget("asyncConsoleTarget", consoleWrapper);
@@ -336,6 +336,11 @@ namespace DCS_SR_Client
                 Logger logger = LogManager.GetCurrentClassLogger();
                 logger.Error((Exception)e.ExceptionObject, "Received unhandled exception, {0}", e.IsTerminating ? "exiting" : "continuing");
             }
+
+#if DEBUG
+            MessageBox.Show("This was an SRS Crash!\nPlease open the logfile: `clientlog.txt` in the folder: `VNGD-SimpleRadioStandalone/DCS-SR-Client/bin/Debug/`. There you will find more information.", "Debug Crash", MessageBoxButton.OK)
+            
+#endif
 #if !DEBUG
             // Request creates an Issue on GitHub with the LogFile
             var client = new HttpClient();

--- a/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsRadioControlGroupTransparent.xaml.cs
+++ b/DCS-SR-Client/UI/AwacsRadioOverlayWindow/AwacsRadioControlGroupTransparent.xaml.cs
@@ -174,13 +174,18 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI.AwacsRadioOverlayWindow
 
             if (_clientStateSingleton.IsConnected && _clientStateSingleton.ExternalAWACSModeConnected)
             {
-                RadioEnabled.Background =
-                    RadioHelper.GetRadio(RadioId).modulation != RadioInformation.Modulation.DISABLED
-                        ? radioOn
-                        : radioOff;
-                RadioEnabled.Content = RadioHelper.GetRadio(RadioId).modulation != RadioInformation.Modulation.DISABLED
-                    ? "On"
-                    : "Off";
+                var radio = RadioHelper.GetRadio(RadioId);
+
+                if (radio != null)
+                {
+                    RadioEnabled.Background = radio.modulation != RadioInformation.Modulation.DISABLED ? radioOn : radioOff;
+                    RadioEnabled.Content = radio.modulation != RadioInformation.Modulation.DISABLED ? "On" : "Off";
+                }
+                else
+                {
+                    Logger.Warn($"Radio with ID: {RadioId} was not found. And could not Toggle.");
+                }
+                
             }
             else
             {

--- a/DCS-SR-Client/UI/Images.cs
+++ b/DCS-SR-Client/UI/Images.cs
@@ -9,6 +9,8 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
         public static BitmapImage IconDisconnected;
         public static BitmapImage IconDisconnectedError;
         public static BitmapImage IconDisconnectedGame;
+        public static BitmapImage IconExpand;
+        public static BitmapImage IconContract;
 
         public static void Init()
         {
@@ -20,6 +22,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Client.UI
             IconDisconnectedError = new BitmapImage(new Uri("pack://application:,,,/SR-ClientRadio;component/status-disconnected-error.png"));
             // Image taken from https://icons8.com/icon/set/computer/metro @ 2018-08-01
             IconDisconnectedGame = new BitmapImage(new Uri("pack://application:,,,/SR-ClientRadio;component/status-disconnected-game.png"));
+            // Expand Icon
+            IconExpand = new BitmapImage(new Uri("pack://application:,,,/SR-ClientRadio;component/ContractIcon.png"));
+            // Contract Icon
+            IconContract = new BitmapImage(new Uri("pack://application:,,,/SR-ClientRadio;component/ExpandIcon.png"));
         }
     }
 }

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayFiveHorizontal.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayFiveHorizontal.xaml
@@ -95,7 +95,7 @@
                 Click="Button_Swap_Orientation"
                 Style="{StaticResource DarkStyle-Button}">
                 <Grid Width="10" Height="10">
-                    <Image Source="../../SRS_Orientation_Toggle.png" />
+                    <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                 </Grid>
             </Button>
             <Button Height="15"

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayOneHorizontal.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayOneHorizontal.xaml
@@ -92,7 +92,7 @@
                 Click="Button_Swap_Orientation"
                 Style="{StaticResource DarkStyle-Button}">
                 <Grid Width="10" Height="10">
-                    <Image Source="../../SRS_Orientation_Toggle.png" />
+                    <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                 </Grid>
             </Button>
             <Button Height="15"

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayOneVertical.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayOneVertical.xaml
@@ -56,7 +56,7 @@
        ToolTip="Swap to horizon orientation">
             <Button.Content>
                 <Grid Width="10" Height="10">
-                    <Image Source="../../SRS_Orientation_Toggle.png" />
+                    <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                 </Grid>
             </Button.Content>
         </Button>

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenHorizontal.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenHorizontal.xaml
@@ -93,7 +93,7 @@
                 Click="Button_Swap_Orientation"
                 Style="{StaticResource DarkStyle-Button}">
                 <Grid Width="10" Height="10">
-                    <Image Source="../../SRS_Orientation_Toggle.png" />
+                    <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                 </Grid>
             </Button>
             <Button Height="15"

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenHorizontalWide.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenHorizontalWide.xaml
@@ -100,7 +100,7 @@
                 Click="Button_Swap_Orientation"
                 Style="{StaticResource DarkStyle-Button}">
                 <Grid Width="10" Height="10">
-                    <Image Source="../../SRS_Orientation_Toggle.png" />
+                    <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                 </Grid>
             </Button>
             <Button Height="15"

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenTransparent.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenTransparent.xaml
@@ -9,7 +9,7 @@
 
     Name="RadioOverlayWin"
         Title="DCS-SimpleRadio"
-        Width="178"
+        Width="180"
         Height= "155"
         MinWidth="178"
         MinHeight="155"
@@ -42,7 +42,7 @@
             Width="180"
             Orientation="Horizontal">
             <TextBlock Name="ControlText"
-                Width="117"
+                Width="130"
                 Height="12"
                 Margin="2,0,0,0"
                 VerticalAlignment="Center"
@@ -62,18 +62,6 @@
                Foreground="#E7E7E7"
                Padding="0"
                Text="Vertical" />
-            <Button Name="buttonOrientation"
-                Margin="0,0,0,0"
-                Visibility="Hidden"
-                Click="Button_Swap_Orientation"
-                Style="{StaticResource DarkStyle-Button}"
-                ToolTip="Swap to horizon orientation">
-                <Button.Content>
-                    <Grid Width="10" Height="10">
-                        <Image Source="../../SRS_Orientation_Toggle.png" />
-                    </Grid>
-                </Button.Content>
-            </Button>
             <Button Name="buttonAbout"
                 Margin="0,0,0,0"
                 Click="Button_About"

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenTransparent.xaml.cs
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenTransparent.xaml.cs
@@ -48,6 +48,9 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
 
         private long _lastUnitId;
 
+        private readonly ImageBrush _expandIcon = new ImageBrush(Images.IconExpand);
+        private readonly ImageBrush _contractIcon = new ImageBrush(Images.IconContract);
+
         private readonly Action<bool, int> _toggleOverlay;
 
         private readonly Action<bool, int> _ExpandPanelImageConverter;
@@ -328,17 +331,10 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
 
         private void Button_Expand(object sender, RoutedEventArgs e)
         {
-            //var expandicon = new ImageBrush(new BitmapImage(new Uri("/ ExpandIcon.png")));
-            //var contracticon = new ImageBrush(new BitmapImage(new Uri("/ ContractIcon.png")));
-
-            // TODO: Refactor this into the XAML and use Project resources
-            var expandicon = new ImageBrush(new BitmapImage(new Uri("../../ExpandIcon.png", UriKind.Relative)));
-            var contracticon = new ImageBrush(new BitmapImage(new Uri("../../ContractIcon.png", UriKind.Relative)));
-
             if ((buttonExpandText.Text == null) || (buttonExpandText.Text == "expand"))
             {
                 buttonExpandText.Text = "contract";
-                buttonExpandText.Background = expandicon;
+                buttonExpandText.Background = _expandIcon;
                 Header.Visibility = Visibility.Collapsed;
                 Footer.Visibility = Visibility.Collapsed;
                 
@@ -347,7 +343,7 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
             else
             {
                 buttonExpandText.Text = "expand";
-                buttonExpandText.Background = contracticon;
+                buttonExpandText.Background = _contractIcon;
                 Header.Visibility = Visibility.Visible;
                 Footer.Visibility = Visibility.Visible;
 
@@ -361,19 +357,11 @@ namespace Ciribob.DCS.SimpleRadio.Standalone.Overlay
             Close();
         }
 
-        //TODO - likely remove this function for the transparency panels (this comment written by dabble)
-        private void Button_Swap_Orientation(object sender, RoutedEventArgs e)
-        {
-            Close();
-            _toggleOverlay(true, 5); // index 5 is the horizontal orientation
-        }
-
         private void textOpacitySlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             //Header
             ControlText.Opacity = e.NewValue;
             Orientation.Opacity = e.NewValue;
-            buttonOrientation.Opacity = e.NewValue;
             buttonAbout.Opacity = e.NewValue;
             buttonMinimize.Opacity = e.NewValue;
             buttonClose.Opacity = e.NewValue;

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenVertical.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenVertical.xaml
@@ -75,7 +75,7 @@
                    ToolTip="Swap to horizon orientation">
                 <Button.Content>
                     <Grid Width="10" Height="10">
-                        <Image Source="../../SRS_Orientation_Toggle.png" />
+                        <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                     </Grid>
                 </Button.Content>
             </Button>

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenVerticalLong.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTenVerticalLong.xaml
@@ -79,7 +79,7 @@
                 ToolTip="Swap to horizon orientation">
                 <Button.Content>
                     <Grid Width="10" Height="10">
-                        <Image Source="../../SRS_Orientation_Toggle.png" />
+                        <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                     </Grid>
                 </Button.Content>
             </Button>

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayThreeHorizontal.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayThreeHorizontal.xaml
@@ -88,7 +88,7 @@
                 Click="Button_Swap_Orientation"
                 Style="{StaticResource DarkStyle-Button}">
                 <Grid Width="10" Height="10">
-                    <Image Source="../../SRS_Orientation_Toggle.png" />
+                    <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                 </Grid>
             </Button>
             <Button Height="15"

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayThreeVertical.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayThreeVertical.xaml
@@ -56,7 +56,7 @@
                 ToolTip="Swap to horizon orientation">
             <Button.Content>
                 <Grid Width="10" Height="10">
-                    <Image Source="../../SRS_Orientation_Toggle.png" />
+                    <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                 </Grid>
             </Button.Content>
         </Button>

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTwoHorizontal.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTwoHorizontal.xaml
@@ -88,7 +88,7 @@
                 Click="Button_Swap_Orientation"
                 Style="{StaticResource DarkStyle-Button}">
                 <Grid Width="10" Height="10">
-                    <Image Source="../../SRS_Orientation_Toggle.png" />
+                    <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                 </Grid>
             </Button>
             <Button Height="15"

--- a/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTwoVertical.xaml
+++ b/DCS-SR-Client/UI/RadioOverlayWindow/RadioOverlayTwoVertical.xaml
@@ -56,7 +56,7 @@
                 ToolTip="Swap to horizon orientation">
             <Button.Content>
                 <Grid Width="10" Height="10">
-                    <Image Source="../../SRS_Orientation_Toggle.png" />
+                    <Image Source="pack://application:,,,/SR-ClientRadio;component/SRS_Orientation_Toggle.png" />
                 </Grid>
             </Button.Content>
         </Button>


### PR DESCRIPTION
Fixed Issue 129 and 128.
Testing needed. But I think I did it.

Problem 1:
 - Icon was loaded with relative Path. This could lead to crashes.
 - Solution: Added it to the official Icon Class with correct Resource association

Problem 2:
 - Radios could be null, but this case was not caught, which lead to some crashes.
 -  Solution: Extra check if radio was found. If not log and ignore.
